### PR TITLE
Issue #73: Make calls to static site secured over https

### DIFF
--- a/it-vibe-fe/makeFile
+++ b/it-vibe-fe/makeFile
@@ -21,4 +21,7 @@ docker-build:
     docker build -t it-vibe-static-site:1.0 .
 
 docker-run:
-    docker run -d -p 8080:80 it-vibe-static-site:1.0
+    docker run -d -zp 8080:80 it-vibe-static-site:1.0
+
+terraform-apply-one-module:
+    terraform plan -target=module.<module_name>

--- a/terraform/front-end/main.tf
+++ b/terraform/front-end/main.tf
@@ -1,7 +1,21 @@
 variable "hosted_zone_id" {}
 
+variable "s3_name" {
+  default = "it-vibe.dev.sema4-conseil.com"
+}
+
+variable "region" {
+  default = "eu-west-3"
+}
+
+locals {
+  s3_origin_id   = "${var.s3_name}-origin"
+  s3_domain_name = "${var.s3_name}.s3-website.${var.region}.amazonaws.com"
+}
+
+
 resource "aws_s3_bucket" "it-vibe-static-site-s3" {
-  bucket = "it-vibe.dev.sema4-conseil.com"
+  bucket = var.s3_name
   tags = {
     Name = "IT-Vibe-s3-bucket-static-web-site"
     Env = "dev"
@@ -91,14 +105,74 @@ resource "aws_s3_bucket_website_configuration" "it-vibe-static-site-s3-configura
 
 }
 
+// CloudFront
+// Create a CloudFront distribution for the static website
+// The distribution will use the S3 bucket as the origin
+// The distribution will be configured to use HTTPS and redirect HTTP requests to HTTPS
+// The distribution will also be configured to use a custom domain name
+
+resource "aws_cloudfront_distribution" "cloudfront_distribution" {
+  aliases = ["it-vibe.dev.sema4-conseil.com"]
+  origin {
+    origin_id                = local.s3_origin_id
+    domain_name              = local.s3_domain_name
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2", "TLSv1.1"]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled      = true
+  comment              = "CloudFront distribution itvibe static website"
+  default_root_object  = "index.html"
+
+  default_cache_behavior {
+    target_origin_id       = local.s3_origin_id
+    viewer_protocol_policy = "redirect-to-https"
+
+    allowed_methods = ["GET", "HEAD"]
+    cached_methods  = ["GET", "HEAD"]
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  price_class = "PriceClass_100"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "arn:aws:acm:us-east-1:327441465709:certificate/ce3fc596-3ce2-4a9c-a9a4-eb1388f7a839"
+    ssl_support_method        = "sni-only"
+    minimum_protocol_version  = "TLSv1.2_2021" # Use the latest protocol version
+  }
+}
+
+
 // Create a route 53 for the static web-site
 resource "aws_route53_record" "s3_static_site" {
   zone_id = var.hosted_zone_id
-  name    = aws_s3_bucket_website_configuration.it-vibe-static-site-s3-configuration.bucket
+  name    = var.s3_name
   type    = "A"
-  alias {
-    name = aws_s3_bucket_website_configuration.it-vibe-static-site-s3-configuration.website_domain
-    zone_id = aws_s3_bucket.it-vibe-static-site-s3.hosted_zone_id 
-    evaluate_target_health = "true"
+   alias {
+    name                   = aws_cloudfront_distribution.cloudfront_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.cloudfront_distribution.hosted_zone_id
+    evaluate_target_health = false
   }
 }


### PR DESCRIPTION
- CloudFront:
	- Create a CloudFront distribution for the static website
	- The distribution will use the S3 bucket as the origin
	- The distribution will be configured to use HTTPS and redirect HTTP requests to HTTPS
	- The distribution will also be configured to use a custom domain name

- Route53:
	- The route 53 will be configured to use the CloudFront distribution as the alias target