### PR TITLE
Issue #122: Invalidate cache when terraform Apply.

### DIFF
--- a/terraform/front-end/main.tf
+++ b/terraform/front-end/main.tf
@@ -177,6 +177,18 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 }
 
+resource "null_resource" "invalidate_cloudfront" {
+  triggers = {
+    # Trigger invalidation when files change
+    run_id = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      aws cloudfront create-invalidation --distribution-id ${aws_cloudfront_distribution.cloudfront_distribution.id} --paths /*
+    EOT
+  }
+}
 
 // Create a route 53 for the static web-site
 resource "aws_route53_record" "s3_static_site" {


### PR DESCRIPTION
- Since no built-in solution for terraform to create a cloudFront invalidation, we have execute the aws command manualy and create invalidation with aws-cli.